### PR TITLE
Add $HOME/.pulumi/bin to the PATH

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -8,6 +8,7 @@ PULUMI_VERSION="${BUILDKITE_PLUGIN_SETUP_PULUMI_VERSION:-$(curl --silent --show-
 
 curl -fsSL https://get.pulumi.com | sh -s -- --version $PULUMI_VERSION
 
+export PATH="$HOME/.pulumi/bin:$PATH"
 pulumi version
 
 USE_OIDC="${BUILDKITE_PLUGIN_SETUP_PULUMI_USE_OIDC:-false}"


### PR DESCRIPTION
This makes the `pulumi` command work out of the box (otherwise it's not found). We might also also want to expose this PATH to make it configurable somehow, but for now, this seems like a reasonable default. (It's also what the install script suggests.)